### PR TITLE
fix self.box NameError in IMAPUploader.open

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -325,6 +325,7 @@ class IMAPUploader:
         self.user = user
         self.password = password
         self.retry = retry
+        self.box = box
 
     def upload(self, box, delivery_time, message, retry = None):
         if retry is None:


### PR DESCRIPTION
Variable required by https://github.com/rgladwell/imap-upload/blob/98fed2e626411775a9b0494a1d86ddc46b0f12e1/imap_upload.py#L353