### PR TITLE
Add `--email-only-folders` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ IMAP Upload is a tool for uploading a local mbox file to IMAP4 server. The most 
 *   Preserve the delivery time of the message. (support date time in From_ line / &ldquo;Received:&rdquo; field / &ldquo;Date:&rdquo; field)
 *   Automatic retry when the connection was aborted which happens frequently on Gmail.
 *   Can write out failed messages in mbox format. (Easy to retry for the failed messages)
+*   Supports IMAP servers that can only store either folders or emails in a folder
 *   Support SSL.
 *   Run on Windows, Mac OS X, Linux, *BSD, and so on.
 *   Command line interface. (No friendly GUI, sorry...)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ You can also recursively import mbox sub-folders using th `-r` option:
 python imap_upload.py --gmail -r path
 ```
 
+If your server only supports email or folders per folder you can use the `--email-only-folders` option together with `-r`. 
+If a mixed content folder is found, the emails of the folder are uploaded to a sub-folder of the same name:
+
+```sh
+python imap_upload.py -r path --email-only-folders
+```
+
+Example:
+```
+**Local**
+  Foo (Folder)
+   -> Bar (Folder)
+   -> Email 1
+   -> Email 2
+
+**Remote**
+  Foo
+    -> Bar (Folder)
+    -> Foo (Folder)
+      -> Email 1
+      -> Email 2
+```
+
 You can use just output the account's mailboxes (folders/labels) list. This is useful if you need to upload to an existing special mailbox (i.e.: Gmail's Send Email label, when using a language different from English):
 
 ```sh

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -47,7 +47,8 @@ class MyOptionParser(OptionParser):
                              "--host=outlook.office365.com --port=993 "
                              "--ssl --retry=3")
         self.add_option("--email-only-folders", action="store_true",  
-                        help="use for servers that do not allow storing emails and subfolders in the same folder")
+                        help="use for servers that do not allow storing emails and subfolders in the same folder"
+                            "only works with -r")
         self.add_option("--host", 
                         help="destination hostname [default: %default]")
         self.add_option("--port", type="int", 

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -46,6 +46,8 @@ class MyOptionParser(OptionParser):
                         help="setup for Office365. Equivalents to "
                              "--host=outlook.office365.com --port=993 "
                              "--ssl --retry=3")
+        self.add_option("--email-only-folders", action="store_true",  
+                        help="use for servers that do not allow storing emails and subfolders in the same folder")
         self.add_option("--host", 
                         help="destination hostname [default: %default]")
         self.add_option("--port", type="int", 
@@ -77,6 +79,7 @@ class MyOptionParser(OptionParser):
         self.set_defaults(host="localhost",
                           ssl=False,
                           r=False,
+                          email_only_folders=False,
                           user="",
                           password="",
                           box="INBOX", 
@@ -250,7 +253,7 @@ def upload(imap, box, src, err, time_fields):
     p.endAll()
 
 
-def recursive_upload(imap, box, src, err, time_fields):
+def recursive_upload(imap, box, src, err, time_fields, email_only_folders):
     for file in os.listdir(src):
         path = src + os.sep + file
         if os.path.isdir(path):
@@ -259,13 +262,30 @@ def recursive_upload(imap, box, src, err, time_fields):
                 subbox = fileName
             else:
                 subbox = box + "/" + fileName
-            recursive_upload(imap, subbox, path, err, time_fields)
+            recursive_upload(imap, subbox, path, err, time_fields, email_only_folders)
         elif file.endswith("mbox"):
             print >>sys.stderr, "Found mailbox at {}...".format(path)
             mbox = mailbox.mbox(path, create=False)
+            if (email_only_folders and has_mixed_content(src)):
+                target_box = box + "/" + src.split(os.sep)[-1]
+            else:
+                target_box = box;
             if err:
                 err = mailbox.mbox(err)
-            upload(imap, box, mbox, err, time_fields)
+            upload(imap, target_box, mbox, err, time_fields)
+
+def has_mixed_content(src):
+    dirFound = False
+    mboxFound = False
+
+    for file in os.listdir(src):
+        path = src + os.sep + file
+        if (os.path.isdir(path)):
+            dirFound = True
+        elif file.endswith("mbox"):
+            mboxFound = True
+
+    return dirFound and mboxFound
 
 def pretty_print_mailboxes(boxes):
     for box in boxes:
@@ -426,6 +446,7 @@ def main(args=None):
         time_fields = options.pop("time_fields")
 
         recurse = options.pop("r")
+        email_only_folders = options.pop("email_only_folders")
 
         # Connect to the server and login
         print >>sys.stderr, \
@@ -450,7 +471,7 @@ def main(args=None):
                     err = mailbox.mbox(err)
                 upload(uploader, options["box"], src, err, time_fields)
             else:
-                recursive_upload(uploader, "", src, err, time_fields)
+                recursive_upload(uploader, "", src, err, time_fields, email_only_folders)
 
         return 0
 


### PR DESCRIPTION
I came across an email servers that was configured to either store emails or sub-folders in a folder. 

I had to add an option to accompany for that behavior. 
I hope you could incorporate this change into this project.

Thanks for all the great work :)