### PR TITLE
Fix regexp in pretty_print_mailboxes

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -290,7 +290,7 @@ def has_mixed_content(src):
 
 def pretty_print_mailboxes(boxes):
     for box in boxes:
-        x = re.search("\(((\\\\[A-Za-z]+\s*)+)\) \"(.)\" \"(.*?)\"",box)
+        x = re.search("\(((\\\\[A-Za-z]+\s*)+)\) \"(\.)\" \"?(.*)\"?",box)
         raw_name = x.group(4)
         sep = x.group(3)
         raw_flags = x.group(1)


### PR DESCRIPTION
Hello,

First of all, thank you very much for your work developping this script, I really appreciate it.

I am facing an error while trying to list the boxes/folders in an IMAP server:
```
Connecting to imap.mydomain.local:143.
Just list mail boxes!
An unknown error has occurred [461]:  'NoneType' object has no attribute 'group'
```
I believe the error is triggered on line 293 because the regexp doesn't match the box string. For my IMAP server the boxes names are like this: 
```
(\HasNoChildren \Junk) "." Junk
(\HasNoChildren \Sent) "." Sent
(\HasNoChildren) "." Borradores
(\HasChildren) "." INBOX
```
I have modified the regexp to make the quotes around the box name optional. Also, I have removed the optional operator after .* and I have added a backslash to convert the any character operator into a dot.

You can check the modified regexp here: https://regex101.com/r/GblvdD/1

Regards,
Jesús Ángel