### PR TITLE
Add Fastmail shortcut and fix pretty print regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IDE
+.idea
+
+# Development environment
+Pipfile

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -302,11 +302,13 @@ def has_mixed_content(src):
 
 def pretty_print_mailboxes(boxes):
     for box in boxes:
-        x = re.search("\(((\\\\[A-Za-z]+\s*)+)\) \"(\.)\" \"?(.*)\"?",box)
+        x = re.search("\(((\\\\[A-Za-z]+\s*)+)\) \"(.*)\" \"?(.*)\"?",box)
+        if not x:
+            print "Could not parse: {}".format(box)
+            continue
         raw_name = x.group(4)
         sep = x.group(3)
         raw_flags = x.group(1)
-        #print pretty_mailboxes_name(raw_name, sep) + "\t\t\t\t\t" + pretty_flags(raw_flags)
         print "{:40s}{}".format(pretty_mailboxes_name(raw_name, sep), pretty_flags(raw_flags))
 
 def pretty_mailboxes_name(name, sep):

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -282,7 +282,7 @@ def recursive_upload(imap, box, src, err, time_fields, email_only_folders):
             if (email_only_folders and has_mixed_content(src)):
                 target_box = box + "/" + src.split(os.sep)[-1]
             else:
-                target_box = box;
+                target_box = box
             if err:
                 err = mailbox.mbox(err)
             upload(imap, target_box, mbox, err, time_fields)

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -46,6 +46,11 @@ class MyOptionParser(OptionParser):
                         help="setup for Office365. Equivalents to "
                              "--host=outlook.office365.com --port=993 "
                              "--ssl --retry=3")
+        self.add_option("--fastmail", action="callback", nargs=0,
+                        callback=self.enable_fastmail,
+                        help="setup for Fastmail hosted IMAP. Equivalent to "
+                             "--host=imap.fastmail.com --port=993 "
+                             "--ssl --retry=3")
         self.add_option("--email-only-folders", action="store_true",  
                         help="use for servers that do not allow storing emails and subfolders in the same folder"
                             "only works with -r")
@@ -87,6 +92,7 @@ class MyOptionParser(OptionParser):
                           retry=0,
                           error=None, 
                           time_fields=["from", "received", "date"])
+
     def enable_gmail(self, option, opt_str, value, parser):
         parser.values.ssl = True
         parser.values.host = "imap.gmail.com"
@@ -96,6 +102,12 @@ class MyOptionParser(OptionParser):
     def enable_office365(self, option, opt_str, value, parser):
         parser.values.ssl = True
         parser.values.host = "outlook.office365.com"
+        parser.values.port = 993
+        parser.values.retry = 3
+
+    def enable_fastmail(self, option, opt_str, value, parser):
+        parser.values.ssl = True
+        parser.values.host = "imap.fastmail.com"
         parser.values.port = 993
         parser.values.retry = 3
 


### PR DESCRIPTION
This PR includes a couple of small modifications I made for my own use case -- in case you want to merge it.

Primarily it adds support for a shortcut command for Fastmail hosted IMAP service.

I also made a [small adjustment to the regex for pretty printing mailboxes](https://github.com/rgladwell/imap-upload/compare/master...cdubz:master#diff-f11fd2129fa69563321b42076d9ac3ca361c8b164d2b7b7f3c4f84d6199f9462L293), which wasn't working at all for me with Fastmail's IMAP response. Curious to have someone test and confirm this change with different services.