### PR TITLE
Fix: support for unicode file names

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -270,8 +270,9 @@ def upload(imap, box, src, err, time_fields):
 
 
 def recursive_upload(imap, box, src, err, time_fields, email_only_folders, separator):
-    for file in os.listdir(src):
-        path = src + os.sep + file
+    usrc = unicode(src)
+    for file in os.listdir(usrc):
+        path = usrc + os.sep + file
         if os.path.isdir(path):
             fileName, fileExtension = os.path.splitext(file)
             if not box:
@@ -280,7 +281,7 @@ def recursive_upload(imap, box, src, err, time_fields, email_only_folders, separ
                 subbox = box + separator + fileName
             recursive_upload(imap, subbox, path, err, time_fields, email_only_folders, separator)
         elif file.endswith("mbox"):
-            print >>sys.stderr, "Found mailbox at {}...".format(path)
+            print >>sys.stderr, u"Found mailbox at {}...".format(path)
             mbox = mailbox.mbox(path, create=False)
             if (email_only_folders and has_mixed_content(src)):
                 target_box = box + separator + src.split(os.sep)[-1]

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -247,7 +247,7 @@ class Progress():
 
 
 def upload(imap, box, src, err, time_fields):
-    print >>sys.stderr, "Uploading to {}...".format(box)
+    print >>sys.stderr, u"Uploading to {}...".format(box)
     print >>sys.stderr, \
           "Counting the mailbox (it could take a while for the large one)."
     p = Progress(len(src))


### PR DESCRIPTION
Script fails with a codec error for mailbox file names with unicode characters:

```
An unknown error has occurred [493]:  'ascii' codec can't decode byte 0xc3 in position 24: ordinal not in range(128)
```

This fixes this bug and closes:

https://github.com/rgladwell/imap-upload/issues/19