### PR TITLE
Fix bug regex between bytes and string

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -400,6 +400,8 @@ class IMAPUploader:
         try:
             self.open()
             self.imap.create(box)
+            if type(message) == str:
+                message = bytes(message, 'utf-8')
             return self.imap.append(box, [], delivery_time, message)
         except (imaplib.IMAP4.abort, socket.error):
             self.close()


### PR DESCRIPTION
Fix a bug when messages are interpreted as a string. They needed to be converted into a bytes object or "imap.append" will fail.

Example logs of the bug : 

IMAP Upload (v2.0.0)
User name:  Connecting to pro2.mail.ovh.net:993.
Uploading to imported...
Counting the mailbox (it could take a while for the large one).
  1/531  12.7 kB  Fwd: Texte pour le      NG (cannot use a bytes pattern on a string-like object)
  1/531 122.2 kB  À la une : Une indemnité de     NG (cannot use a bytes pattern on a string-like object)
  1/531  46.3 kB  Fwd: Vos stats du mois de jui    NG (cannot use a bytes pattern on a string-like object)
  1/531   2.9 kB  Location cam                    NG (cannot use a bytes pattern on a string-like object)
  1/531  11.7 MB  Image lonchea                    NG (cannot use a bytes pattern on a string-like object)
  1/531 104.9 kB  RE: Location - Clip video        NG (cannot use a bytes pattern on a string-like object)
  1/531  42.3 kB  Location - Clip video            NG (cannot use a bytes pattern on a string-like object)
  1/531 342.7 kB  Re: Demande pour le lieu    NG (cannot use a bytes pattern on a string-like object)
  1/531  16.8 kB  Re: Demande pour le lieu          NG (cannot use a bytes pattern on a string-like object)
  1/531  20.4 kB  Re: Demande pour le lieu          (Reconnect)

