### PR TITLE
Fixed empty box bug

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -285,7 +285,7 @@ def recursive_upload(imap, box, src, err, time_fields, email_only_folders, separ
             if (email_only_folders and has_mixed_content(src)):
                 target_box = box + separator + src.split(os.sep)[-1]
             else:
-                target_box = box
+                target_box = file.split(".")[0]
             if err:
                 err = mailbox.mbox(err)
             upload(imap, target_box, mbox, err, time_fields)

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -285,7 +285,7 @@ def recursive_upload(imap, box, src, err, time_fields, email_only_folders, separ
             if (email_only_folders and has_mixed_content(src)):
                 target_box = box + separator + src.split(os.sep)[-1]
             else:
-                target_box = file.split(".")[0]
+                target_box = file.split('.')[0] if (box is None or box == "") else box
             if err:
                 err = mailbox.mbox(err)
             upload(imap, target_box, mbox, err, time_fields)


### PR DESCRIPTION
In the given line, the application crashes for me because of an empty box variable.

My parameters: 
`-r $FileDir$ --host imap.strato.de --port 993 --ssl --user ... --password ...`

In the FileDir, multiple mbox files are available (INBOX, ....)
I could solve the issue by passing the current mbox name as the new box to the upload.

I couldn't see (within a few minutes) why the box should be empty in this line. Therefore, I opened up this pull request.

Nevertheless, many thanks for the great script! It helped me to sync from one server to another!