### PR TITLE
Fix broken --list_boxes

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -470,6 +470,7 @@ def has_mixed_content(src):
 
 def pretty_print_mailboxes(boxes):
     for box in boxes:
+        box = imap_utf7.decode(box)
         x = re.search("\(((\\\\[A-Za-z]+\s*)+)\) \"(.*)\" \"?(.*)\"?",box)
         if not x:
             print("Could not parse: {}".format(box))


### PR DESCRIPTION
convert "boxes" parameter in pretty_print_mailboxes from bytes array to
properly decoded string using imap_utf7.decode to fix broken
"--list_boxes" option.