### PR TITLE
Supply requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+IMAPClient==2.2.0


### PR DESCRIPTION
To manifest a configuration known to be working, add a requirements.txt
that can be used to install requirements with `pip install -r
requirements.txt.`