### PR TITLE
Ensure error output on non zero exit

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -721,10 +721,12 @@ def main(args=None):
         return 130
     except Exception as e:
         exc_type, exc_obj, exc_tb = sys.exc_info()
-        print("An unknown error has occurred [{}]: ".format(exc_tb.tb_lineno), e)
+        print("An unknown error has occurred [{}]: {}".format(exc_tb.tb_lineno), e)
         return 1
 
 
 if __name__ == "__main__":
     print("IMAP Upload (v{})".format(__version__))
-    sys.exit(main())
+    result = main()
+    sys.stdout.flush()
+    sys.exit(result)


### PR DESCRIPTION
Flush stdout before exit to ensure that all output of print is actually
written to stdout.

Add missing format string parameter to print statement in case of
unexpected exception in main().