### PR TITLE
Maximum message size exceeded are warnings (New option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Options:
   --google-takeout-language=GOOGLE_TAKEOUT_LANGUAGE
                         [Use specific language. Supported languages: 'en es ca
                         de'. default: en]
+  --maximum-size-exceeded-are-warnings
+                        Treat 'maximum size exceeded messages' as warnings and
+                        not as errors.
   --debug               Debug: Make some error messages more verbose.
   --dry-run             Do not perform IMAP writing actions
 ```

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -411,13 +411,13 @@ class Progress():
         print("OK (%d sec)" % \
               math.ceil(time.time() - self.time_began))
 
-    def endNg(self, err):
+    def endError(self, err):
         """Called when an error has occurred while processing a message."""
-        print("NG (%s)" % err)
+        print("ERROR (%s)" % err)
 
     def endAll(self):
         """Called when all message was processed."""
-        print("Done. (OK: %d, NG: %d)" % \
+        print("Done. (OK: %d, ERROR: %d)" % \
               (self.ok_count, self.total_count - self.ok_count))
 
 
@@ -456,12 +456,12 @@ def upload(imap, box, src, err, time_fields, google_takeout=False, google_takeou
             p.endOk()
             continue
         except socket.error as e:
-            p.endNg("Socket error: " + str(e))
+            p.endError("Socket error: " + str(e))
         except Exception as e:
             if debug:
-                p.endNg(traceback.format_exc())
+                p.endError(traceback.format_exc())
             else:
-                p.endNg(e)
+                p.endError(e)
         if err is not None:
             err.add(msg)
     p.endAll()

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -253,6 +253,7 @@ class Progress():
                  google_takeout_label_priority=None, google_takeout_language="en"):
         self.total_count = total_count
         self.ok_count = 0
+        self.warning_count = 0
         self.count = 0
         self.format = "%" + str(len(str(total_count))) + "d/" + \
                       str(total_count) + " %5.1f %-2s  %s  "
@@ -414,6 +415,10 @@ class Progress():
     def endError(self, err):
         """Called when an error has occurred while processing a message."""
         print("ERROR (%s)" % err)
+
+    def endWarning(self, err):
+        """Called when a warning has occurred while processing a message."""
+        print("WARNING (%s)" % err)
 
     def endAll(self):
         """Called when all message was processed."""


### PR DESCRIPTION
When debugging (or with daily usage) you can find many of these messages that they are not being saved onto the imap server.

Many of them are not saved because their size is bigger than the maximum message size that the imap server allows.

In that case a message similar to `APPEND command error: BAD [b'maximum message size exceeded']` appears.

My usecase for these messages is the following one:
- Treat these errors as warnings. (I already expect those big messages not to be uploaded)
- Do not save those messages onto the error mbox (I do not intend to try to upload them again).

However I don't think this new option has to be enabled by default for these reasons:
- My usecase is quite specific.
- The current documentation encourages using the error mbox to retry later to import the messages.
- The current behaviour treats these messages as errors

```
  --maximum-size-exceeded-are-warnings
                        Treat 'maximum size exceeded messages' as warnings and
                        not as errors.
```