### PR TITLE
Fix unknown-8bit errors

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -29,6 +29,24 @@ if sys.version_info < (3, 5):
     print("IMAP Upload requires Python 3.5 or later.")
     sys.exit(1)
 
+# Avoid "KeyError: 'content-transfer-encoding'" error.
+# Inspired from https://github.com/python/cpython/issues/71508#issuecomment-1093718177
+# This workaround might no longer needed when python 3.10 is a minimum version
+# That way you could just use msg.as_string()
+class ImapUploadMessage(email.message.Message):
+
+    @staticmethod
+    def as_string(self):
+        # Work around for https://bugs.python.org/issue27321 and
+        # https://bugs.python.org/issue32330.
+        try:
+            value = email.message.Message.as_string(self)
+        except (KeyError, LookupError, UnicodeEncodeError):
+            value = email.message.Message.as_bytes(self).decode(
+                'ascii', 'replace')
+        # Also ensure no unicode surrogates in the returned string.
+        return email.utils._sanitize(value)
+
 class MyOptionParser(OptionParser):
     def __init__(self):
         usage = "usage: python %prog [options] (MBOX|-r MBOX_FOLDER) [DEST]\n"\
@@ -255,7 +273,7 @@ class Progress():
     def begin(self, msg):
         """Called when start proccessing of a new message."""
         self.time_began = time.time()
-        size, prefix = si_prefix(float(len(msg.as_string())), threshold=0.8)
+        size, prefix = si_prefix(float(len(ImapUploadMessage.as_string(msg))), threshold=0.8)
         sbj = decode_header_to_string(msg["subject"] or "")
         if self.google_takeout:
             if (self.google_takeout_language == "en"):
@@ -441,7 +459,7 @@ def upload(imap, box, src, err, time_fields, google_takeout=False, google_takeou
                     msg_boxes = msg.boxes
                 for i in range(len(msg_boxes)):
                     r, r2 = imap.upload(box, msg.get_delivery_time(time_fields),
-                                        msg.as_string(), msg.flags, msg_boxes[i], 3)
+                                        ImapUploadMessage.as_string(msg), msg.flags, msg_boxes[i], 3)
                     if r != "OK":
                         raise Exception(r2[0]) # FIXME: Should use custom class
             else:

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -213,10 +213,16 @@ def decode_header_to_string(header):
     """Decodes an email message header (possibly RFC2047-encoded)
     into a string, while working around https://bugs.python.org/issue22833"""
 
+    def _decode(value, encoding):
+        if isinstance(value, str):
+            return value
+        if ((not encoding) or (encoding == 'unknown-8bit')):
+            encoding = 'ascii'
+        return value.decode(encoding, 'replace')
+
     return "".join(
-        alleged_string if isinstance(alleged_string, str) else alleged_string.decode(
-            alleged_charset or 'ascii')
-        for alleged_string, alleged_charset in email.header.decode_header(header))
+        _decode(bytestr, encoding)
+        for bytestr, encoding in email.header.decode_header(header))
 
 all_chars = (chr(i) for i in range(sys.maxunicode))
 categories = {'Cc', 'Cf', 'Cs', 'Co', 'Cn'}

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -209,36 +209,6 @@ def si_prefix(n, prefixes=("", "k", "M", "G", "T", "P", "E", "Z", "Y"),
         return (n, prefixes[0])
     return si_prefix(n / block, prefixes[1:])
 
-
-def str_width(s):
-    """Get string width."""
-    w = 0
-    for c in str(s):
-        w += 1 + (unicodedata.east_asian_width(c) in "FWA")
-    return w
-
-
-def trim_width(s, width):
-    """Get truncated string with specified width."""
-    trimed = []
-    for c in str(s):
-        width -= str_width(c)
-        if width <= 0:
-            break
-        trimed.append(c)
-    return "".join(trimed)
-
-
-def left_fit_width(s, width, fill=' '):
-    """Make a string fixed width by padding or truncating.
-
-    Note: fill can't be full width character.
-    """
-    s = trim_width(s, width)
-    s += fill * (width - str_width(s))
-    return s
-
-
 def decode_header_to_string(header):
     """Decodes an email message header (possibly RFC2047-encoded)
     into a string, while working around https://bugs.python.org/issue22833"""
@@ -247,6 +217,17 @@ def decode_header_to_string(header):
         alleged_string if isinstance(alleged_string, str) else alleged_string.decode(
             alleged_charset or 'ascii')
         for alleged_string, alleged_charset in email.header.decode_header(header))
+
+all_chars = (chr(i) for i in range(sys.maxunicode))
+categories = {'Cc', 'Cf', 'Cs', 'Co', 'Cn'}
+control_chars = ''.join(c for c in all_chars if unicodedata.category(c) in categories)
+# or equivalently and much more efficiently
+#control_chars = ''.join(map(chr, itertools.chain(range(0x00,0x20), range(0x7f,0xa0))))
+
+control_char_re = re.compile('[%s]' % re.escape(control_chars))
+
+def remove_control_chars(s):
+    return control_char_re.sub('', s)
 
 
 class Progress():
@@ -394,7 +375,7 @@ class Progress():
                 msg.boxes.append(only_label)
 
         print(self.format % \
-              (self.count + 1, size, prefix + "B", left_fit_width(sbj, 30)),
+              (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))),
               "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
 
     def get_label_by_prio(self, labels):


### PR DESCRIPTION
Avoid errors parsing emails with wrong detected subject encoding.
Also workaround python bug with some bad formed emails ( https://github.com/python/cpython/issues/71508 ).

This pull request builds on https://github.com/rgladwell/imap-upload/pull/53 so it's meant to be approved once the former pull request has been merged into upstream.