### PR TITLE
Fix: failing for non-Google Takeout usage

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -409,9 +409,9 @@ class Progress():
                 msg.boxes = []
                 msg.boxes.append(only_label)
 
-        print(self.format % \
-              (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))),
-              "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
+            print(self.format % \
+                  (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))),
+                  "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
 
     def get_label_by_prio(self, labels):
         labels = [label[0] for label in labels]


### PR DESCRIPTION
Script fails on line 414 with the error message:

`ERROR ('mboxMessage' object has no attribute 'boxes')`

This moves broken code into the scope which contains msg.boxes.

Resolves:

https://github.com/rgladwell/imap-upload/issues/56