### PR TITLE
Fix: verbose logging disabled for non takeout

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -412,9 +412,9 @@ class Progress():
             print(self.format % \
                   (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))),
                   "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
-          else
+        else:
             print(self.format % \
-              (self.count + 1, size, prefix + "B", left_fit_width(sbj, 30)), end=' ')
+                (self.count + 1, size, prefix + "B", left_fit_width(sbj, 30)), end=' ')
 
     def get_label_by_prio(self, labels):
         labels = [label[0] for label in labels]

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -412,6 +412,9 @@ class Progress():
             print(self.format % \
                   (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))),
                   "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
+          else
+            print(self.format % \
+              (self.count + 1, size, prefix + "B", left_fit_width(sbj, 30)), end=' ')
 
     def get_label_by_prio(self, labels):
         labels = [label[0] for label in labels]

--- a/imap_upload.py
+++ b/imap_upload.py
@@ -414,7 +414,7 @@ class Progress():
                   "to [%s]" % (",".join(x[0] for x in msg.boxes)), end=' ')
         else:
             print(self.format % \
-                (self.count + 1, size, prefix + "B", left_fit_width(sbj, 30)), end=' ')
+                (self.count + 1, size, prefix + "B", '{:30.30}'.format(remove_control_chars(sbj))), end=' ')
 
     def get_label_by_prio(self, labels):
         labels = [label[0] for label in labels]


### PR DESCRIPTION
Verbose logging was disabled for non-Google Takeout imports, by this change:

https://github.com/rgladwell/imap-upload/pull/35

This PR re-enables it.