### PR TITLE
Make the script installable

### DIFF
--- a/imap_upload.py
+++ b/imap_upload.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 # coding=utf-8
+"""A tool to upload email to IMAP mailboxes."""
 import codecs
 import email
 import email.header

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "imap-upload"
+dynamic = ["version", "description"]
+dependencies = [
+  "IMAPClient>=2.2.0,<3",
+]
+requires-python = ">= 3.5"
+readme = "README.md"
+license = "MIT"
+license-files = ["License.txt"]
+
+[project.urls]
+Repository = "https://github.com/rgladwell/imap-upload"
+
+[project.scripts]
+imap-upload = "imap_upload:main"
+
+[build-system]
+requires = ["flit_core>=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.module]
+name = "imap_upload"


### PR DESCRIPTION
This way, the tool can be installed with e.g.:

    pipx install .

And, run with:

    imap-upload --help

---

This is a first step towards having an installable package on PyPI.